### PR TITLE
Add configurations to define a custom truststore

### DIFF
--- a/Ballerina.lock
+++ b/Ballerina.lock
@@ -1,4 +1,4 @@
 org_name = "wso2"
-version = "0.9.51"
+version = "0.9.52"
 lockfile_version = "1.0.0"
 ballerina_version = "1.0.1"

--- a/Ballerina.toml
+++ b/Ballerina.toml
@@ -1,6 +1,6 @@
 [project]
 org-name = "wso2"
-version = "0.9.51"
+version = "0.9.52"
 license= ["Apache-2.0"]
 authors = ["WSO2"]
 keywords = ["ballerina", "amazons3", "amazon", "client", "connector"]

--- a/src/amazons3/amazons3_client.bal
+++ b/src/amazons3/amazons3_client.bal
@@ -50,7 +50,11 @@ public type AmazonS3Client client object {
                         message = CLIENT_CREDENTIALS_VERIFICATION_ERROR_MSG, cause = verificationStatus);
             return clientConfigInitializationError;
         } else {
-            self.amazonS3 = new(baseURL, amazonS3Config.clientConfig);
+            http:ClientSecureSocket? clientSecureSocket = amazonS3Config?.secureSocketConfig;
+            if (clientSecureSocket is http:ClientSecureSocket) {
+                amazonS3Config.clientConfig.secureSocket = clientSecureSocket;
+            }
+                self.amazonS3  = new(baseURL, amazonS3Config.clientConfig);
         }
     }
 
@@ -382,9 +386,11 @@ function verifyCredentials(string accessKeyId, string secretAccessKey) returns C
 # + region - The AWS Region. If you don't specify an AWS region, AmazonS3Client uses US East (N. Virginia) as 
 #            default region.
 # + clientConfig - HTTP client config
+# + secureSocketConfig - Secure Socket config
 public type ClientConfiguration record {
     string accessKeyId;
     string secretAccessKey;
     string region = DEFAULT_REGION;
     http:ClientConfiguration clientConfig = {http1Settings: {chunking: http:CHUNKING_NEVER}};
+    http:ClientSecureSocket secureSocketConfig?;
 };


### PR DESCRIPTION
## Purpose
Make Amazon S3 connector accept configurations from a custom truststore when a user has provided truststore configurations.